### PR TITLE
move CI further along

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Graphics::TIFF.
 
+13  Thu, 06 May 2021 19:37 -0400
+        - Makefile.PL fix Makemaker API error (return '';)
+        - tiffperl.h  use TIFFPERL_H_ style
+
 12  Thu, 29 Apr 2021 22:30 +0200
         - Changes to tests to fix RT 122933
           (t/1.t test crashes with ImageMagick 7.0.6.9)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -81,7 +81,7 @@ sub MY::postamble {
 
     # GNU Make extensions that BSD make doesn't like.
     # Author-only stuff, so comment out for non-Linux.
-    if ( $OSNAME ne 'linux' ) { return }
+    if ( $OSNAME ne 'linux' ) { return ''; }
     return <<'END';
 SHELL = bash
 MANIFEST = $(shell cat MANIFEST)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use 5.008;
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.5503;
 use ExtUtils::Depends;
 use ExtUtils::PkgConfig;
 use English;
@@ -24,7 +24,7 @@ if (
     }
   )
 {
-    $lib = $pkgcfg{libs};
+    $lib .= $pkgcfg{libs};
     $inc .= $pkgcfg{cflags};
     $runtime_reqs{libtiff} = $pkgcfg{modversion};
 }
@@ -36,6 +36,7 @@ WriteMakefile(
     VERSION_FROM       => 'lib/Graphics/TIFF.pm',    # finds $VERSION
     PREREQ_PM          => { Readonly => 0 },         # e.g., Module::Name => 1.1
     CONFIGURE_REQUIRES => {
+	'ExtUtils::MakeMaker' => 6.5503,
         'ExtUtils::Depends'   => 0,
         'ExtUtils::PkgConfig' => 0
     },
@@ -81,7 +82,7 @@ sub MY::postamble {
 
     # GNU Make extensions that BSD make doesn't like.
     # Author-only stuff, so comment out for non-Linux.
-    if ( $OSNAME ne 'linux' ) { return ''; }
+    if ( $OSNAME ne 'linux' ) { return '' }
     return <<'END';
 SHELL = bash
 MANIFEST = $(shell cat MANIFEST)

--- a/tiffperl.h
+++ b/tiffperl.h
@@ -12,4 +12,4 @@
 /* Include all of libtiff's headers for internal consistency */
 #include <tiffio.h>
 
-#endif // TIFFPERL_H_
+#endif  // TIFFPERL_H_

--- a/tiffperl.h
+++ b/tiffperl.h
@@ -6,10 +6,10 @@
  * at your option, any later version of Perl 5 you may have available.
  */
 
-#ifndef _TIFFPERL_H_
-#define _TIFFPERL_H_
+#ifndef TIFFPERL_H_
+#define TIFFPERL_H_
 
 /* Include all of libtiff's headers for internal consistency */
 #include <tiffio.h>
 
-#endif /* _TIFFPERL_H_ */
+#endif // TIFFPERL_H_


### PR DESCRIPTION
Fix $to_write error, clean up so CI works (just Ubuntu -- you took out Windows?). Perl 5.26 and 5.32 appear to build and install correctly, but 5.22 still chokes on $(INST_DYNAMIC_LIB) not defined (bad Makefile). Someone is calling static_lib() in Depends.pm, which outputs the undefined INST_DYNAMIC_LIB. I suspect it has something to do with using dmake instead of gmake, but haven't yet found who calls static_lib(). The Depends.pm POD mentions explicitly calling method get_makefile_vars() from Makefile.PL, but that would be a major restructuring of the Makefile.PL.