### PR TITLE
Locate TIFF.pm by %INC

### DIFF
--- a/t/90_MANIFEST.t
+++ b/t/90_MANIFEST.t
@@ -17,7 +17,7 @@ SKIP: {
 }
 
 local $INPUT_RECORD_SEPARATOR = undef;
-my $file = 'lib/Graphics/TIFF.pm';
+my $file = $INC{'Graphics/TIFF.pm'};
 open my $fh, '<:encoding(UTF8)', $file
   or die "Error: cannot open $file\n";
 my $text = <$fh>;


### PR DESCRIPTION
t/90_MANIFEST.t used to inspect ./lib/Graphics/TIFF.pm file. That's
wrong because it's a source from ./lib and all other tests operate on
files from ./blib. It also prevents from runnig the test against
installed files.

This patch fixes it by retrieving the file location from %INC hash
populated by the previous "use Graphics::TIFF ':all';".