### PR TITLE
Adjust to tiff-4.4.0 output

### DIFF
--- a/TIFF.xs
+++ b/TIFF.xs
@@ -643,6 +643,14 @@ tiff_ReadTile (tif, x, y, z, s)
                 }
 		_TIFFfree(buf);
 
+uint16_t
+tiff_CurrentDirectory (tif)
+                TIFF            *tif
+        CODE:
+                RETVAL = TIFFCurrentDirectory(tif);
+        OUTPUT:
+                RETVAL
+
 void
 tiff_PrintDirectory (tif, file, flags)
                 TIFF            *tif

--- a/examples/tiffinfo.pl
+++ b/examples/tiffinfo.pl
@@ -287,6 +287,7 @@ sub readrawdata {
 
 sub tiffinfo {
     my ( $tif, $order, $flags, $is_image ) = @_;
+    printf("=== TIFF directory %d ===\n", $tif->CurrentDirectory);
     $tif->PrintDirectory( *STDOUT, $flags );
     if ( not $readdata or not $is_image ) { return }
     if ($rawdata) {

--- a/lib/Graphics/TIFF.pm
+++ b/lib/Graphics/TIFF.pm
@@ -653,6 +653,10 @@ reversal is done if the FillOrder tag is opposite to the native machine bit
 order. 16- and 32-bit samples are automatically byte-swapped if the file was
 written with a byte order opposite to the native machine byte order.
 
+=head2 $tif->CurrentDirectory()
+
+Return an index number of the current directory in the specified TIFF file.
+
 =head2 $tif->PrintDirectory(file, flags)
 
 Prints a description of the current directory in the specified TIFF file to the

--- a/t/92_tiffinfo.t
+++ b/t/92_tiffinfo.t
@@ -72,6 +72,8 @@ my $expected = `tiffinfo -? $file 2>&1`;
 $expected =~ s/'\?'/?/xsm;
 # strip a description line added in libtiff 4.3.0
 $expected =~ s/^Display information about TIFF files\R\R//sm;
+# strip unsupported -M option added in libtiff 4.4.0
+$expected =~ s/^ -M size\tset the memory allocation limit in MiB\. 0 to disable limit\R//sm;
 is( `$cmd -? $file 2>&1`, $expected, '-?' );
 
 #########################


### PR DESCRIPTION
tiffinfo of tiff-4.4.0 added a directory index and -M option. That
broke t/92_tiffinfo.t.

This patch adds CurrentDirectory() method to the Perl module and
prints the directory index by tiffinfo.pl. Of that breaks
compatibility with the previous tiff library versions.

This patch adjusts t/92_tiffinfo.t to ignore the new -M option. The
option is used to refuse loading large images.

https://rt.cpan.org/Ticket/Display.html?id=143153