### PR TITLE
Remove unused variables

### DIFF
--- a/TIFF.xs
+++ b/TIFF.xs
@@ -286,7 +286,7 @@ tiff_GetField (tif, tag)
                 uint64_t        *aui;
                 float           f;
                 float           *af;
-                int             vector_length, nvals;
+                int             nvals;
         PPCODE:
 /* See http://www.libtiff.org/man/TIFFGetField.3t.html */
                 switch (tag) {
@@ -409,7 +409,6 @@ tiff_GetFieldDefaulted (tif, tag)
                 uint32_t        ui32;
                 uint64_t        *aui;
                 float           f;
-                int             vector_length;
         PPCODE:
                 switch (tag) {
                     /* byte single uint8 */


### PR DESCRIPTION
GCC 13.1.1 warns:

TIFF.xs: In function ‘XS_Graphics__TIFF_GetField’: TIFF.xs:289:33: warning: unused variable ‘vector_length’ [-Wunused-variable]
  289 |                 int             vector_length, nvals;
      |                                 ^~~~~~~~~~~~~
TIFF.xs: In function ‘XS_Graphics__TIFF_GetFieldDefaulted’:
TIFF.xs:412:33: warning: unused variable ‘vector_length’ [-Wunused-variable]
  412 |                 int             vector_length;
      |                                 ^~~~~~~~~~~~~

This patch removes these unused variables.